### PR TITLE
[codex] Polish cross-page UX feedback

### DIFF
--- a/app/family/settings-client.tsx
+++ b/app/family/settings-client.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-import { Card, Pill, SectionTitle } from "@/components/ui";
+import { Card, LoadingBlock, Pill, SectionTitle } from "@/components/ui";
 import { INPUT_LIMITS, limitLabel } from "@/lib/input-limits";
 
 type Member = {
@@ -26,6 +26,8 @@ export function FamilySettingsClient({
   );
   const [familyError, setFamilyError] = useState("");
   const [memberError, setMemberError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [pendingAction, setPendingAction] = useState<"family" | "add-member" | "rename-member" | "">("");
   const [isPending, startTransition] = useTransition();
 
   function refresh() {
@@ -34,8 +36,10 @@ export function FamilySettingsClient({
 
   function updateFamilyName() {
     setFamilyError("");
+    setSuccessMessage("");
 
     startTransition(async () => {
+      setPendingAction("family");
       const response = await fetch("/api/family", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -46,17 +50,22 @@ export function FamilySettingsClient({
 
       if (!response.ok) {
         setFamilyError(data.error || "家族名を更新できませんでした");
+        setPendingAction("");
         return;
       }
 
+      setSuccessMessage("家族名を更新しました。");
+      setPendingAction("");
       refresh();
     });
   }
 
   function addMember() {
     setMemberError("");
+    setSuccessMessage("");
 
     startTransition(async () => {
+      setPendingAction("add-member");
       const response = await fetch("/api/family/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -67,18 +76,23 @@ export function FamilySettingsClient({
 
       if (!response.ok) {
         setMemberError(data.error || "メンバーを追加できませんでした");
+        setPendingAction("");
         return;
       }
 
       setNewMemberName("");
+      setSuccessMessage("メンバーを追加しました。");
+      setPendingAction("");
       refresh();
     });
   }
 
   function renameMember(userId: string) {
     setMemberError("");
+    setSuccessMessage("");
 
     startTransition(async () => {
+      setPendingAction("rename-member");
       const response = await fetch(`/api/family/members/${userId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -89,9 +103,12 @@ export function FamilySettingsClient({
 
       if (!response.ok) {
         setMemberError(data.error || "表示名を更新できませんでした");
+        setPendingAction("");
         return;
       }
 
+      setSuccessMessage("表示名を更新しました。");
+      setPendingAction("");
       refresh();
     });
   }
@@ -105,12 +122,21 @@ export function FamilySettingsClient({
           <input maxLength={INPUT_LIMITS.family_name} value={familyName} onChange={(event) => setFamilyName(event.target.value)} />
           <p className="mt-1 text-xs text-slate-500">{limitLabel(familyName.length, INPUT_LIMITS.family_name)}</p>
         </div>
-        {familyError ? <p className="text-sm text-red-600">{familyError}</p> : null}
+        {familyError ? <p className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700">{familyError}</p> : null}
+        {successMessage && pendingAction !== "add-member" && pendingAction !== "rename-member" ? (
+          <p className="rounded-2xl bg-emerald-50 px-4 py-3 text-sm text-emerald-800">{successMessage}</p>
+        ) : null}
         <button type="button" className="btn-primary w-full" onClick={updateFamilyName} disabled={isPending}>
           家族名を更新
         </button>
+        {isPending && pendingAction === "family" ? (
+          <LoadingBlock
+            title="家族名を更新しています"
+            description="この家族で使う表示名を保存しています。"
+          />
+        ) : null}
 
-        <div className="rounded-2xl bg-slate-50 p-4 text-sm text-slate-600">
+        <div className="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
           今は同じ家族の中でユーザーを切り替えて使います。削除や招待はまだ入れていません。
         </div>
       </Card>
@@ -145,13 +171,22 @@ export function FamilySettingsClient({
                 }
               />
               <p className="mt-1 text-xs text-slate-500">{limitLabel((memberNames[member.userId] || "").length, INPUT_LIMITS.user_name)}</p>
-              <button type="button" className="btn-secondary mt-3" onClick={() => renameMember(member.userId)} disabled={isPending}>
+              <button type="button" className="btn-secondary mt-3 w-full md:w-auto" onClick={() => renameMember(member.userId)} disabled={isPending}>
                 表示名を更新
               </button>
             </div>
           ))}
         </div>
-        {memberError ? <p className="text-sm text-red-600">{memberError}</p> : null}
+        {memberError ? <p className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700">{memberError}</p> : null}
+        {successMessage && pendingAction !== "family" ? (
+          <p className="rounded-2xl bg-emerald-50 px-4 py-3 text-sm text-emerald-800">{successMessage}</p>
+        ) : null}
+        {isPending && pendingAction !== "family" ? (
+          <LoadingBlock
+            title={pendingAction === "add-member" ? "メンバーを追加しています" : "表示名を更新しています"}
+            description={pendingAction === "add-member" ? "家族の切り替え候補に新しいメンバーを追加しています。" : "この家族で使う表示名を保存しています。"}
+          />
+        ) : null}
       </Card>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,7 +54,7 @@ select {
 }
 
 .btn-secondary {
-  @apply inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50;
+  @apply inline-flex items-center justify-center rounded-2xl border border-slate-400 bg-white px-4 py-3 text-sm font-semibold text-slate-800 hover:bg-slate-50;
 }
 
 .field-label {

--- a/app/observations/page.tsx
+++ b/app/observations/page.tsx
@@ -51,7 +51,7 @@ function ObservationTree({
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
               <p className="text-base font-semibold text-slate-900">{node.label}</p>
-              <p className="mt-1 text-xs text-slate-500">
+              <p className="mt-1 text-xs text-slate-600">
                 {fieldTypeLabel(node.type)} / {roleLabel(node.role)}
               </p>
             </div>
@@ -67,9 +67,9 @@ function ObservationTree({
             <div className="rounded-2xl bg-white/80 px-3 py-2 text-sm text-slate-700">今回は使わない: {node.skippedCount}回</div>
           </div>
           {node.why ? <p className="mt-3 text-sm text-slate-700">理由: {node.why}</p> : null}
-          {node.howToUse ? <p className="mt-2 text-xs text-slate-500">使い方: {node.howToUse}</p> : null}
+          {node.howToUse ? <p className="mt-2 text-xs text-slate-600">使い方: {node.howToUse}</p> : null}
           {node.lastSelectedQuestionText ? (
-            <p className="mt-2 text-xs text-slate-500">
+            <p className="mt-2 text-xs text-slate-600">
               最後に使った問い: {node.lastSelectedQuestionText}
               {node.lastSelectedAt ? ` (${new Date(node.lastSelectedAt).toLocaleDateString("ja-JP")})` : ""}
             </p>
@@ -96,7 +96,7 @@ export default async function ObservationsPage() {
           <p className="mb-3 text-sm text-slate-600">見方の地図</p>
           <h1 className="text-3xl font-bold text-slate-900">まだ見方の地図はありません</h1>
           <p className="mt-3 max-w-2xl text-slate-700">最初の問いを作ると、この願いで見ていく項目のまとまりがここにたまっていきます。</p>
-          <div className="mt-6 flex gap-3">
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
             <Link href="/questions" className="btn-primary">
               問いを作る
             </Link>
@@ -117,9 +117,9 @@ export default async function ObservationsPage() {
           <div className="max-w-3xl">
             <h1 className="text-3xl font-bold text-slate-900">この願いの見方の地図</h1>
             <p className="mt-3 text-slate-700">願い: {payload.wishText}</p>
-            <p className="mt-2 text-sm text-slate-600">今の問い: {payload.activeQuestionText}</p>
+            <p className="mt-2 text-sm text-slate-700">今の問い: {payload.activeQuestionText}</p>
           </div>
-          <div className="flex gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             <Link href="/" className="btn-secondary">
               ホームへ戻る
             </Link>
@@ -185,7 +185,7 @@ export default async function ObservationsPage() {
           <SectionTitle>つながり</SectionTitle>
           <Pill>この願いで見ていく項目</Pill>
         </div>
-        <p className="mt-3 text-sm text-slate-600">大きい項目から細かい項目へのつながりをたどれます。今の問いで使う項目は強調表示されます。</p>
+        <p className="mt-3 text-sm text-slate-700">大きい項目から細かい項目へのつながりをたどれます。今の問いで使う項目は強調表示されます。</p>
         <div className="mt-4">
           <ObservationTree nodes={payload.tree} />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,7 +59,7 @@ export default async function HomePage({
             </div>
           </div>
           <div className="rounded-3xl bg-white p-4 shadow-sm">
-            <p className="text-sm text-slate-500">いまのナビ</p>
+            <p className="text-sm text-slate-600">いまのナビ</p>
             <div className="mt-3 flex items-start gap-4">
               <div className="relative h-20 w-20 shrink-0 rounded-[2rem] bg-[radial-gradient(circle_at_35%_30%,#fff7d6,#ffd166_55%,#ffb703)] shadow-sm">
                 <div className="absolute left-4 top-6 h-2.5 w-2.5 rounded-full bg-slate-800" />
@@ -89,7 +89,7 @@ export default async function HomePage({
         <Card className="md:col-span-2">
           <SectionTitle>ここまでのようす</SectionTitle>
           <p className="mt-3 text-slate-700">{home.trajectory_summary}</p>
-          {home.recent_reflection_summary ? <p className="mt-3 text-sm text-slate-500">この前の気づき: {home.recent_reflection_summary}</p> : null}
+          {home.recent_reflection_summary ? <p className="mt-3 text-sm text-slate-600">この前の気づき: {home.recent_reflection_summary}</p> : null}
         </Card>
       </div>
 
@@ -141,7 +141,7 @@ export default async function HomePage({
             )}
           </div>
           {home.observation_summary.recentAdded.length > 0 ? (
-            <p className="mt-4 text-xs text-slate-500">最近ふえた項目: {home.observation_summary.recentAdded.join(" / ")}</p>
+            <p className="mt-4 text-xs text-slate-600">最近ふえた項目: {home.observation_summary.recentAdded.join(" / ")}</p>
           ) : null}
         </Card>
       </div>
@@ -154,7 +154,7 @@ export default async function HomePage({
           </div>
           {params.from === "reflection" ? <p className="mt-3 text-sm font-medium text-amber-800">振り返りで見えてきたことをもとに、今の願いを続けるか、別の願いを始めるか決めよう。</p> : null}
           <p className="mt-3 text-slate-700">{home.next_step_summary}</p>
-          <div className="mt-5 flex gap-3">
+          <div className="mt-5 flex flex-col gap-3 sm:flex-row">
             <Link href={`/records?source=next_step&questionId=${home.active_question_id}`} className="btn-primary">
               記録を1件追加
             </Link>
@@ -162,7 +162,7 @@ export default async function HomePage({
               振り返る
             </Link>
           </div>
-          <div className="mt-3 flex gap-3">
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row">
             <Link href={`/questions?mode=continue${params.from === "reflection" ? "&from=reflection" : ""}`} className="btn-secondary">
               今の願いの次の問い
             </Link>
@@ -187,7 +187,7 @@ export default async function HomePage({
             ) : (
               home.recent_records.map((record) => (
                 <article key={record.id} className="rounded-2xl bg-slate-50 p-3">
-                  <p className="text-xs text-slate-500">{new Date(record.recordedAt).toLocaleString("ja-JP")}</p>
+                  <p className="text-xs text-slate-600">{new Date(record.recordedAt).toLocaleString("ja-JP")}</p>
                   <p className="mt-1 font-medium text-slate-900">{record.body}</p>
                 </article>
               ))

--- a/components/observation-field-editor.tsx
+++ b/components/observation-field-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
-import { SectionTitle } from "@/components/ui";
+import { LoadingBlock, SectionTitle } from "@/components/ui";
 
 export type EditableObservationField = {
   id: string;
@@ -57,6 +57,7 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
   const [isAdding, setIsAdding] = useState(false);
   const [error, setError] = useState("");
   const [customError, setCustomError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
   const [isPending, startTransition] = useTransition();
   const [customField, setCustomField] = useState({
     label: "",
@@ -81,6 +82,7 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
 
   function addCustomField() {
     setCustomError("");
+    setSuccessMessage("");
     const label = customField.label.trim();
 
     if (!label) {
@@ -137,6 +139,7 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
 
   function saveFields() {
     setError("");
+    setSuccessMessage("");
 
     const hasSelected = draftFields.some((field) => field.isSelected);
 
@@ -178,6 +181,7 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
         allFields: (data.all_fields || []) as EditableObservationField[],
       };
       setDraftFields(payload.allFields);
+      setSuccessMessage("見方を更新しました。");
       onSaved(payload);
     });
   }
@@ -190,7 +194,7 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
           {isAdding ? "追加を閉じる" : "項目を足す"}
         </button>
       </div>
-      <p className="text-sm text-slate-600">
+      <p className="text-sm text-slate-700">
         問いはそのままにして、今見る項目や名前を育てられます。保存済みの記録本文は書き換えず、項目の見方だけを更新します。
       </p>
 
@@ -308,17 +312,24 @@ export function ObservationFieldEditor({ fields, onSaved }: ObservationFieldEdit
             </div>
           </div>
           {customError ? <p className="mt-3 text-sm text-red-600">{customError}</p> : null}
-          <div className="mt-3 flex gap-3">
-            <button type="button" className="btn-primary" onClick={addCustomField}>追加する</button>
-            <button type="button" className="btn-secondary" onClick={() => setIsAdding(false)}>閉じる</button>
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+            <button type="button" className="btn-primary w-full sm:w-auto" onClick={addCustomField}>追加する</button>
+            <button type="button" className="btn-secondary w-full sm:w-auto" onClick={() => setIsAdding(false)}>閉じる</button>
           </div>
         </div>
       ) : null}
 
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {error ? <p className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p> : null}
+      {successMessage ? <p className="rounded-2xl bg-emerald-50 px-4 py-3 text-sm text-emerald-800">{successMessage}</p> : null}
       <button type="button" className="btn-primary w-full md:w-auto" onClick={saveFields} disabled={isPending}>
         {isPending ? "更新中..." : "見方を更新する"}
       </button>
+      {isPending ? (
+        <LoadingBlock
+          title="見方を更新しています"
+          description="この問いで使う項目と名前を、保存済みの記録を保ったまま更新しています。"
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What changed

This PR applies the final cross-page UX polish for MVP v1.2 by improving readability, mobile button layout, and action feedback across several existing screens.

Main changes:

- strengthened `btn-secondary` contrast so secondary actions remain visible enough across pages
- improved mobile stacking for multi-button sections on the home screen and observation map screen
- slightly increased contrast for weak helper text and metadata labels where reading felt too faint
- added loading and success/error feedback to the family settings flow
- added loading and success feedback to the observation field editor so updates feel consistent with the rest of the app

## Why

After the main MVP v1.2 UX fixes, the remaining issues were smaller but spread across multiple screens:

- some secondary actions were visually too weak
- some button groups wrapped poorly on narrow screens
- some save/update flows still had weaker feedback than the newer question and record flows

This PR is the final consistency pass to make those screens feel aligned.

## Impact

For users:

- secondary actions are easier to see
- mobile layouts are less cramped in multi-button sections
- save/update actions feel more predictable across family settings and field editing

For product consistency:

- newer feedback patterns introduced in earlier PRs are now applied more broadly instead of only in one screen

## Validation

- `pnpm lint`

## Notes

- unrelated local changes in `app/reflection/reflection-client.tsx`, `app/questions/page.tsx`, `app/questions/questions-client.tsx`, `docs/product/mvp-design.md`, `docs/product/adopted-decisions.md`, `docs/product/current-invariants.md`, `next-env.d.ts`, `.codex`, and `tmp_mvp_v1_2_parent_issue.md` were intentionally excluded from this PR
- this is a polish PR and does not change the data model or API surface