### PR TITLE
[codex] Disable metadata format detection

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,18 @@
 import "./globals.css";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { ReactNode } from "react";
 import { NavLink } from "@/components/nav-link";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "自由研究ナビ",
   description: "願いを今日の一歩に変えるためのMVP",
+  formatDetection: {
+    telephone: false,
+    date: false,
+    email: false,
+    address: false,
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## What changed
- typed `metadata` as `Metadata` in `app/layout.tsx`
- disabled automatic format detection for telephone, date, email, and address in page metadata

## Why
Some browsers, especially Safari, can auto-detect and rewrite telephone numbers or dates in the rendered DOM. Disabling format detection reduces the risk of client-side DOM differences that can contribute to hydration issues.

## User impact
- fewer browser-driven automatic text rewrites
- lower risk of hydration mismatches caused by auto-linking or auto-formatting

## Validation
- `npm run lint`
- `npm run build` currently fails on `main` because `app/page.tsx` imports `formatDateTimeInAppTimeZone` before that helper is merged into `main`.
  - Error: `Module "@/lib/utils" has no exported member 'formatDateTimeInAppTimeZone'.`
  - This PR does not introduce that error; it is an existing dependency on the pending timezone bugfix branch/PR.